### PR TITLE
Fix CI cron not building new versions for old minors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ jobs:
       script:
         - docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
 
-        - bin/image build latest 
-        - bin/image test latest 
-        - bin/image push latest
+        - bin/image build new_versions
+        - bin/image test new_versions
+        - bin/image push new_versions
 
 
     - name: Build and push docker images for the last 4 minor kube-versions

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,10 @@ jobs:
       script:
         - docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
 
-        - bin/image build new_versions
-        - bin/image test new_versions
-        - bin/image push new_versions
+        - bin/image set_versions missing
+        - bin/image build
+        - bin/image test
+        - bin/image push
 
 
     - name: Build and push docker images for the last 4 minor kube-versions
@@ -19,8 +20,9 @@ jobs:
       script:
         - docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
 
-        - bin/image build last4minors $TRAVIS_TAG
-        - bin/image test last4minors $TRAVIS_TAG
+        - bin/image set_versions last4minors
+        - bin/image build $TRAVIS_TAG
+        - bin/image test $TRAVIS_TAG
 
-        - test -z "$TRAVIS_TAG" || bin/image push last4minors $TRAVIS_TAG
+        - test -z "$TRAVIS_TAG" || bin/image push $TRAVIS_TAG
 

--- a/bin/image
+++ b/bin/image
@@ -4,11 +4,9 @@
 # Builds, tests and pushes docker images for different versions of kubernetes
 #
 
-set -o errexit
 set -o pipefail
+set -o errexit
 set -o nounset
-
-TAG=${3:-$(cat VERSION)}
 
 latest_version() { 
     curl -sSL https://storage.googleapis.com/kubernetes-release/release/stable.txt
@@ -28,13 +26,13 @@ last4minors() {
     done
 }
 
-# filters kube versions which are already pushed
-# missing_from_repo <VERSION...>
-missing_from_repo() {
-    present_tags=$(curl -sSL https://registry.hub.docker.com/v1/repositories/claranet/gcloud-kubectl-docker/tags)
+# filters kube versions which were already pushed to dockerhub
+# missing_from_registry <VERSION...>
+missing_from_registry() {
+    dockerhub_tags=$(curl -sSL https://registry.hub.docker.com/v1/repositories/claranet/gcloud-kubectl-docker/tags)
 
     for version in $@; do
-        echo $present_tags | jq '.[] | .name' | grep $version > /dev/null || echo $version
+        echo $dockerhub_tags | jq '.[] | .name' | grep $version > /dev/null || echo $version
     done
 }
 
@@ -42,6 +40,14 @@ missing_from_repo() {
 build_images() {
     for version in $@; do 
         docker build -t claranet/gcloud-kubectl-docker:${version}-${TAG} --build-arg KUBE_VERSION=$version .
+    done
+}
+
+# test_images <VERSION...>
+test_images() {
+    for version in $@; do
+        docker run claranet/gcloud-kubectl-docker:${version}-${TAG} \
+            sh -c "helm version --client && gcloud version && kubectl version --client && kubeadm version"
     done
 }
 
@@ -62,44 +68,63 @@ push_images() {
     done
 }
 
-# test_images <VERSION...>
-test_images() {
-    for version in $@; do 
-        docker run claranet/gcloud-kubectl-docker:${version}-${TAG} \
-            sh -c "helm version --client && gcloud version && kubectl version --client && kubeadm version"
-    done
-}
-
 print_usage() {
-    printf "\nUsage: $0 <build|push> <latest|last4minors|VERSION> (<TAG>)\n\n"
+    printf "\nUsage: $0 <set_version|set_versions> <latest|last4minors|missing|VERSIONS>\n       $0 <build|test|push> (<TAG>)\n\n"
     exit 1
 }
 
-case $2 in 
+get_versions() {
+    cat /tmp/gcloud-kubectl-docker-versions
+}
 
-    latest)
-        versions=$(latest_version) 
-        ;;
-    last4minors)
-        versions=$(last4minors)
-        ;;
-    new_versions)
-        versions=$(missing_from_repo $(last4minors))
-        ;;
-    *) 
-        versions=$2
-esac
+set_versions() {
+
+    set +o nounset
+    [[ -z "$1" ]] && print_usage
+    set -o nounset
+
+    case "$1" in
     
-case $1 in
-    
+        # latest minor and patch version
+        latest)
+            versions=$(latest_version)
+            ;;
+        # latest patch versions of the last 4 minors
+        last4minors)
+            versions=$(last4minors)
+            ;;
+        # latest patch versions of the last 4 minors, which haven't been pushed to the registry
+        missing)
+            versions="$(missing_from_registry $(last4minors))"
+            ;;
+        *)
+            versions="$@"
+    esac
+
+    echo "$versions" > /tmp/gcloud-kubectl-docker-versions
+}
+
+set +o nounset
+[[ -z "$1" ]] && print_usage
+set -o nounset
+
+case "$1" in
+
+    set_version|set_versions)
+        shift
+        set_versions $@
+        ;;
     build)
-        build_images $versions
+        TAG=${2:-$(cat VERSION)}
+        build_images $(get_versions)
         ;;
     test)
-        test_images $versions
+        TAG=${2:-$(cat VERSION)}
+        test_images $(get_versions)
         ;;
     push)
-        push_images $versions
+        TAG=${2:-$(cat VERSION)}
+        push_images $(get_versions)
         ;;
     *)
         print_usage

--- a/bin/image
+++ b/bin/image
@@ -28,6 +28,16 @@ last4minors() {
     done
 }
 
+# filters kube versions which are already pushed
+# missing_from_repo <VERSION...>
+missing_from_repo() {
+    present_tags=$(curl -sSL https://registry.hub.docker.com/v1/repositories/claranet/gcloud-kubectl-docker/tags)
+
+    for version in $@; do
+        echo $present_tags | jq '.[] | .name' | grep $version > /dev/null || echo $version
+    done
+}
+
 # build_images <VERSION...>
 build_images() {
     for version in $@; do 
@@ -72,6 +82,9 @@ case $2 in
         ;;
     last4minors)
         versions=$(last4minors)
+        ;;
+    new_versions)
+        versions=$(missing_from_repo $(last4minors))
         ;;
     *) 
         versions=$2


### PR DESCRIPTION
Currently patch versions for older minors are not build by the travis cronjob. They are only build by the regular CI job.
e.g. 1.12.4 hasn't been build yet because it released after 1.13 and is thus not the "latest" version overall

This PR:
- adds a new version option "new_versions" to the build script, which builds/tests/pushes all versions which haven't been pushed to the registry yet
- changes cronjob to use the new option