### PR TITLE
Fix version detection and docker image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,10 +43,13 @@ RUN curl -sSL https://pkg.cfssl.org/R1.2/cfssl_linux-amd64 > /usr/bin/cfssl \
  && curl -sSL https://pkg.cfssl.org/R1.2/cfssljson_linux-amd64 > /usr/bin/cfssljson \
  && chmod +x /usr/bin/cfssl /usr/bin/cfssljson
 
-RUN curl -sSL https://github.com/roboll/helmfile/releases/download/v0.81.3/helmfile_linux_amd64 -o /usr/bin/helmfile \
- && chmod +x /usr/bin/helmfile
+RUN mkdir -p /tmp/helmfile; \
+    curl -sSL https://github.com/helmfile/helmfile/releases/download/v0.153.1/helmfile_0.153.1_linux_amd64.tar.gz -o /tmp/helmfile/helmfile.tar.gz; \
+    tar xvzf /tmp/helmfile/helmfile.tar.gz -C /tmp/helmfile; \
+    mv /tmp/helmfile/helmfile /usr/bin/helmfile; \
+    chmod +x /usr/bin/helmfile;
 
-RUN helm plugin install https://github.com/databus23/helm-diff --version v2.11.0+5
+RUN helm plugin install https://github.com/databus23/helm-diff --version v3.7.0
 
 # Install kubectl and kubeadm
 RUN curl -sSL ${KUBE_BINARY_URL}/kubectl -o /usr/bin/kubectl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ RUN apk add --no-cache \
     git \
     openssh-client \
     openssl \
-    python \
-    py2-pip
+    python3 \
+    py3-pip
 
 # install docker
 COPY --from=docker:18 /usr/local/bin/docker* /usr/local/bin/
@@ -24,7 +24,7 @@ RUN pip install --upgrade pip
 # install docker-compose
 RUN apk add --no-cache --virtual build-deps \
     gcc \
-    python-dev \
+    python3-dev \
     libffi-dev \
     openssl-dev \
     libc-dev \

--- a/bin/image
+++ b/bin/image
@@ -14,12 +14,12 @@ latest_version() {
 
 # get_latest_for_minor <MINOR_VERSION> <KUBE_TAGS>
 get_latest_for_minor() { 
-    echo $2 | jq '.[] | .name' | grep v1.$1 | grep -v "-" | sort -r --version-sort | head -n1 | tr -d '"'
+    echo $2 | jq '.[] | .tag_name' | grep v1.$1 | grep -v "-" | sort -r --version-sort | head -n1 | tr -d '"'
 }
 
 last4minors() {
     current_minor=$(latest_version | cut -d "." -f2)
-    kube_tags=$(curl -sSL https://registry.hub.docker.com/v1/repositories/cruse/kube-apiserver-amd64/tags)
+    kube_tags=$(curl -sSL https://api.github.com/repos/kubernetes/kubernetes/releases)
 
     for minor in $(seq $((current_minor - 3)) $current_minor); do
         get_latest_for_minor $minor "$kube_tags"
@@ -29,10 +29,10 @@ last4minors() {
 # filters kube versions which were already pushed to dockerhub
 # missing_from_registry <VERSION...>
 missing_from_registry() {
-    dockerhub_tags=$(curl -sSL https://registry.hub.docker.com/v1/repositories/claranet/gcloud-kubectl-docker/tags)
+    dockerhub_tags=$(curl -sSL https://registry.hub.docker.com/v2/repositories/claranet/gcloud-kubectl-docker/tags)
 
     for version in $@; do
-        echo $dockerhub_tags | jq '.[] | .name' | grep $version > /dev/null || echo $version
+        echo $dockerhub_tags | jq '.results[] | .name' | grep $version > /dev/null || echo $version
     done
 }
 


### PR DESCRIPTION
We had several issues in the build which will be fixed by this PR: 
- Outdated APIs to retrieve versions
- Deprecated python references in Dockerfile